### PR TITLE
add query to display request count by backend to latency routing test

### DIFF
--- a/end_to_end_tests/scenario_latency_routing.py
+++ b/end_to_end_tests/scenario_latency_routing.py
@@ -168,6 +168,36 @@ def on_test_stop(environment, **kwargs):
     time_range = f"TimeGenerated > datetime({test_start_time.strftime('%Y-%m-%dT%H:%M:%SZ')}) and TimeGenerated < datetime({test_stop_time.strftime('%Y-%m-%dT%H:%M:%SZ')})"
 
     query_processor.add_query(
+        title="Request count by backend (PTU1 -> Blue, PAYG1 -> Yellow)",
+        query=f"""
+ApiManagementGatewayLogs
+| where OperationName != "" and  {time_range}
+| where BackendId != ""
+| summarize request_count = count() by bin(TimeGenerated, 10s), BackendId
+| order by TimeGenerated asc
+| render timechart
+        """.strip(),  # When clicking on the link, Log Analytics runs the query automatically if there's no preceding whitespace
+        is_chart=True,
+        chart_config={
+            "height": 15,
+            "min": 0,
+            "colors": [
+                asciichart.yellow,
+                asciichart.blue,
+            ],
+        },
+        group_definition=GroupDefinition(
+            id_column="TimeGenerated",
+            group_column="BackendId",
+            value_column="request_count",
+            missing_value=float("nan"),
+        ),
+        timespan=(test_start_time, test_stop_time),
+        show_query=True,
+        include_link=True,
+    )
+
+    query_processor.add_query(
         title="Request latency (PAYG1 -> Blue, PAYG2 -> Yellow)",
         query=f"""
 ApiManagementGatewayLogs


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- adds request count by backend to latency routing e2e test so that users can more easily see how traffic is routed to the PAYG backend when PTU latency spikes

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
- run the `run-end-to-end-latency-routing.sh` script

## What to Check
- second query showing request count by backend should display