### PR TITLE
'workloadName' is not valid if resource_name_prefix is more than 8 characters

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
 AZURE_LOCATION='eastus'
-RESOURCE_NAME_PREFIX='apimgenaidemo' # This should be less than equal to 8 characters since workloadName should be less than or equal to 8 
+RESOURCE_NAME_PREFIX='apimgen' # This should be less than equal to 8 characters since workloadName should be less than or equal to 8 
 ENVIRONMENT_TAG='dev'
 
 # By default, the GenAI Gateway capabilities deploy using a simulator

--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
 AZURE_LOCATION='eastus'
-RESOURCE_NAME_PREFIX='apimgenaidemo'
+RESOURCE_NAME_PREFIX='apimgenaidemo' # This should be less than equal to 8 characters since workloadName should be less than or equal to 8 
 ENVIRONMENT_TAG='dev'
 
 # By default, the GenAI Gateway capabilities deploy using a simulator


### PR DESCRIPTION
## Purpose
'workloadName' is not valid if resource_name_prefix is more than 8 characters. 

![Screenshot 2024-05-14 at 11 46 32 AM](https://github.com/Azure-Samples/apim-genai-gateway-toolkit/assets/15818044/7f5f64bc-38b4-4aa6-846d-67520073e2f9)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```



