### PR TITLE
Add .gitattributes to force LF for .sh and .env files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set bash scripts and .env files to use LF line endings regardless of the platform
+# used to clone the code
+*.sh text eol=lf
+*.env text eol=lf


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Force LF line endings regardless of the OS/filesystem that the code is cloned to. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Clone the code to a Windows file system

```
git clone [repo-address]
cd [repo-name]
```

* Test the code
Open the repo in VS Code and open a `.sh` file or `sample.env` and validate that it shows as LF endings (i.e. not CRLF) in the status bar:

![image](https://github.com/Azure-Samples/apim-genai-gateway-toolkit/assets/1824461/04f8a928-e021-4e61-aedf-967f7ff27647)

