### PR TITLE
Switch to using secret for mounting simulator deployment config

### DIFF
--- a/infra/simulators/base.bicep
+++ b/infra/simulators/base.bicep
@@ -50,8 +50,5 @@ output appInsightsName string = appInsightsName
 output containerRegistryLoginServer string = simulatorBase.outputs.containerRegistryLoginServer
 output containerRegistryName string = simulatorBase.outputs.containerRegistryName
 
-output storageAccountName string = simulatorBase.outputs.storageAccountName
-output fileShareName string = simulatorBase.outputs.fileShareName
-
 output keyVaultName string = simulatorBase.outputs.keyVaultName
 output containerAppEnvName string = simulatorBase.outputs.containerAppEnvName

--- a/infra/simulators/modules/simulatorBase.bicep
+++ b/infra/simulators/modules/simulatorBase.bicep
@@ -23,7 +23,6 @@ param appInsightsName string
 
 var containerRegistryName = replace('${resourceSuffix}', '-', '')
 var keyVaultName = replace('${resourceSuffix}', '-', '')
-var storageAccountName = replace('${resourceSuffix}', '-', '')
 var containerAppEnvName = resourceSuffix
 
 
@@ -78,22 +77,7 @@ resource additionalSecretReader 'Microsoft.Authorization/roleAssignments@2020-04
     }
   }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
-  name: storageAccountName
-  location: location
-  sku: {
-    name: 'Standard_LRS'
-  }
-  kind: 'StorageV2'
-}
-resource fileService 'Microsoft.Storage/storageAccounts/fileServices@2023-01-01' = {
-  parent: storageAccount
-  name: 'default'
-}
-resource simulatorFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-01-01' = {
-  parent: fileService
-  name: 'simulator'
-}
+
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
   name: logAnalyticsName
@@ -129,23 +113,9 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2023-11-02-preview' 
     }
   }
 }
-resource containerAppStorage 'Microsoft.App/managedEnvironments/storages@2023-05-01' = {
-  parent: containerAppEnv
-  name: 'simulator-storage'
-  properties: {
-    azureFile: {
-      shareName: simulatorFileShare.name
-      accountName: storageAccount.name
-      accountKey: storageAccount.listKeys().keys[0].value
-      accessMode: 'ReadWrite'
-    }
-  }
-}
 
 output containerRegistryLoginServer string = containerRegistry.properties.loginServer
 output containerRegistryName string = containerRegistry.name
-output storageAccountName string = storageAccount.name
-output fileShareName string = simulatorFileShare.name
 output keyVaultName string = vault.name
 output containerAppEnvName string = containerAppEnv.name
 output appInsightsName string = appInsights.name

--- a/infra/simulators/simulators.bicep
+++ b/infra/simulators/simulators.bicep
@@ -29,7 +29,6 @@ param simulatorApiKey string
 param containerAppEnvName string
 param containerRegistryName string
 param keyVaultName string
-param storageAccountName string
 param appInsightsName string
 
 @description('The tag of the simulator image to deploy')
@@ -49,14 +48,12 @@ module simulatorPTU1 'modules/simulatorInstance.bicep' = {
     containerRegistryName: containerRegistryName
     simulatorImageTag: simulatorImageTag
     keyVaultName: keyVaultName
-    storageAccountName: storageAccountName
     appInsightsName: appInsightsName
     simulatorApiKey: simulatorApiKey
     apiSimulatorNameSuffix: 'ptu1'
     simulatorMode: 'generate'
     extensionPath: '' // no extensions used currently
     logLevel: 'INFO'
-    openAIDeploymentConfigPath:'/mnt/simulator/simulator_deployment_config.json'
     azureOpenAIEndpoint:'' // only needed for record mode
     azureOpenAIKey:'' // only needed for record mode
     recordingAutoSave: 'false' // only needed for record mode
@@ -74,14 +71,12 @@ module simulatorPAYG1 'modules/simulatorInstance.bicep' = {
     containerRegistryName: containerRegistryName
     simulatorImageTag: simulatorImageTag
     keyVaultName: keyVaultName
-    storageAccountName: storageAccountName
     appInsightsName: appInsightsName
     simulatorApiKey: simulatorApiKey
     apiSimulatorNameSuffix: 'payg1'
     simulatorMode: 'generate'
     extensionPath: '' // no extensions used currently
     logLevel: 'INFO'
-    openAIDeploymentConfigPath:'/mnt/simulator/simulator_deployment_config.json'
     azureOpenAIEndpoint:'' // only needed for record mode
     azureOpenAIKey:'' // only needed for record mode
     recordingAutoSave: 'false' // only needed for record mode
@@ -99,14 +94,12 @@ module simulatorPAYG2 'modules/simulatorInstance.bicep' = {
     containerRegistryName: containerRegistryName
     simulatorImageTag: simulatorImageTag
     keyVaultName: keyVaultName
-    storageAccountName: storageAccountName
     appInsightsName: appInsightsName
     simulatorApiKey: simulatorApiKey
     apiSimulatorNameSuffix: 'payg2'
     simulatorMode: 'generate'
     extensionPath: '' // no extensions used currently
     logLevel: 'INFO'
-    openAIDeploymentConfigPath:'/mnt/simulator/simulator_deployment_config.json'
     azureOpenAIEndpoint:'' // only needed for record mode
     azureOpenAIKey:'' // only needed for record mode
     recordingAutoSave: 'false' // only needed for record mode

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -254,26 +254,6 @@ EOF
   fi
   
   #
-  # Upload simulator deployment config files to file share
-  #
-  echo "Uploading simulator config files to file share..."
-  storage_account_name=$(jq -r '.storageAccountName // ""' < "$output_simulator_base")
-  if [[ -z "$storage_account_name" ]]; then
-    echo "Storage account name (storageAccountName) not found in output-simulator-base.json"
-    exit 1
-  fi
-
-  file_share_name=$(jq -r '.fileShareName // ""' < "$output_simulator_base")
-  if [[ -z "$file_share_name" ]]; then
-    echo "File share name (fileShareName) not found in output-simulator-base.json"
-    exit 1
-  fi
-
-  storage_key=$(az storage account keys list --account-name "$storage_account_name" -o tsv --query '[0].value')
-
-  az storage file upload-batch --destination "$file_share_name" --source "$script_dir/../infra/simulators/simulator_file_content" --account-name "$storage_account_name" --account-key "$storage_key"
-
-  #
   # Deploy simulator instances
   #
   key_vault_name=$(jq -r '.keyVaultName // ""' < "$output_simulator_base")
@@ -318,9 +298,6 @@ cat << EOF > "$script_dir/../infra/simulators/azuredeploy.parameters.json"
     },
     "keyVaultName": {
       "value": "${key_vault_name}"
-    },
-    "storageAccountName": {
-      "value": "${storage_account_name}"
     },
     "appInsightsName": {
       "value": "${app_insights_name}"


### PR DESCRIPTION
Switch to using secret for mounting simulator deployment config

This provides a mechanism for updating the model deployment config and auto updating the simulator via the deploy.sh script (as it triggers a new revision)