### PR TITLE
Return 404 for deployments not configured

### DIFF
--- a/capabilities/batch-processing-alt1/batch-processing-policy.xml
+++ b/capabilities/batch-processing-alt1/batch-processing-policy.xml
@@ -61,10 +61,17 @@
                             return deployment;
                         }
                     }
-                    // default to first deployment
-                    // TODO - what should the behaviour here be?
-                    return deployments[0];
+                    // Deployment not found
+                    return null;
                 }" />
+                <choose>
+                    <when condition="@(context.Variables["selected-deployment"] == null)">
+                        <return-response>
+                            <set-status code="404" reason="Deployment not found" />
+                            <set-body>Deployment not found</set-body>
+                        </return-response>
+                    </when>
+                </choose>
                 <set-variable name="tpm-limit" value="@{
                     JObject selectedDeployment = (JObject)context.Variables["selected-deployment"];
                     return selectedDeployment.Value<int>("tpm-limit");

--- a/infra/simulators/modules/simulatorInstance.bicep
+++ b/infra/simulators/modules/simulatorInstance.bicep
@@ -182,6 +182,7 @@ resource apiSim 'Microsoft.App/containerApps@2023-05-01' = {
             // https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html#opentelemetry.sdk.environment_variables.OTEL_SERVICE_NAME
             { name: 'OTEL_SERVICE_NAME', value: apiSimulatorName }
             { name: 'OTEL_METRIC_EXPORT_INTERVAL', value: '10000' } // metric export interval in milliseconds
+            { name: 'ALLOW_UNDEFINED_OPENAI_DEPLOYMENTS', value: 'False' }
           ]
           volumeMounts: [
             {


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Change the simulator (and batch-processing-alt1) behavoiur to return a 404 when called for model deployments that have not been configured.
This makes errors more obvious, saving time

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Deploy and call an API specifying a model deployment name that hasn't been configured.

## What to Check
Verify that you get a 404 response

## Other Information
<!-- Add any other helpful information that may be needed here. -->