### PR TITLE
Set minimum API version for APIM

### DIFF
--- a/infra/apim-genai/modules/apiManagement.bicep
+++ b/infra/apim-genai/modules/apiManagement.bicep
@@ -68,6 +68,9 @@ resource apiManagementService 'Microsoft.ApiManagement/service@2023-05-01-previe
   properties: {
     publisherEmail: publisherEmail
     publisherName: publisherName
+    apiVersionConstraint: {
+      minApiVersion: '2019-12-01'
+    }
   }
   identity: {
     type: 'SystemAssigned'

--- a/infra/apim-genai/modules/apiManagement.bicep
+++ b/infra/apim-genai/modules/apiManagement.bicep
@@ -58,7 +58,7 @@ param appInsightsName string
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource apiManagementService 'Microsoft.ApiManagement/service@2023-05-01-preview' = {
+resource apiManagementService 'Microsoft.ApiManagement/service@2024-05-01' = {
   name: apiManagementServiceName
   location: location
   sku: {
@@ -77,7 +77,7 @@ resource apiManagementService 'Microsoft.ApiManagement/service@2023-05-01-previe
   }
 }
 
-resource azureOpenAISimpleRoundRobinAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAISimpleRoundRobinAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-simple-round-robin'
   properties: {
@@ -86,10 +86,13 @@ resource azureOpenAISimpleRoundRobinAPI 'Microsoft.ApiManagement/service/apis@20
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAISimpleRoundRobinAPIv2 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAISimpleRoundRobinAPIv2 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-simple-round-robin-v2'
   properties: {
@@ -98,10 +101,13 @@ resource azureOpenAISimpleRoundRobinAPIv2 'Microsoft.ApiManagement/service/apis@
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIWeightedRoundRobinAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIWeightedRoundRobinAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-weighted-round-robin'
   properties: {
@@ -110,10 +116,13 @@ resource azureOpenAIWeightedRoundRobinAPI 'Microsoft.ApiManagement/service/apis@
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIWeightedRoundRobinAPIv2 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIWeightedRoundRobinAPIv2 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-weighted-round-robin-v2'
   properties: {
@@ -122,10 +131,13 @@ resource azureOpenAIWeightedRoundRobinAPIv2 'Microsoft.ApiManagement/service/api
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIRetryWithPayAsYouGoAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIRetryWithPayAsYouGoAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-retry-with-payg'
   properties: {
@@ -134,10 +146,13 @@ resource azureOpenAIRetryWithPayAsYouGoAPI 'Microsoft.ApiManagement/service/apis
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIRetryWithPayAsYouGoAPIv2 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIRetryWithPayAsYouGoAPIv2 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-retry-with-payg-v2'
   properties: {
@@ -146,10 +161,13 @@ resource azureOpenAIRetryWithPayAsYouGoAPIv2 'Microsoft.ApiManagement/service/ap
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAILatencyRoutingAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAILatencyRoutingAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-latency-routing'
   properties: {
@@ -158,10 +176,13 @@ resource azureOpenAILatencyRoutingAPI 'Microsoft.ApiManagement/service/apis@2023
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIUsageTrackingAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIUsageTrackingAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-usage-tracking'
   properties: {
@@ -170,10 +191,13 @@ resource azureOpenAIUsageTrackingAPI 'Microsoft.ApiManagement/service/apis@2023-
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIPrioritizationTokenCalculatingAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIPrioritizationTokenCalculatingAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-prioritization-token-calculating'
   properties: {
@@ -182,10 +206,13 @@ resource azureOpenAIPrioritizationTokenCalculatingAPI 'Microsoft.ApiManagement/s
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIPrioritizationTokenTrackingAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource azureOpenAIPrioritizationTokenTrackingAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-api-prioritization-tracking'
   properties: {
@@ -194,10 +221,13 @@ resource azureOpenAIPrioritizationTokenTrackingAPI 'Microsoft.ApiManagement/serv
     protocols: ['https']
     value: loadTextContent('../api-specs/openapi-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource helperAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
+resource helperAPI 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   parent: apiManagementService
   name: 'helper-apis'
   properties: {
@@ -206,10 +236,13 @@ resource helperAPI 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' = {
     protocols: ['https']
     value: loadTextContent('../api-specs/support-api-spec.json')
     format: 'openapi+json'
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+    }
   }
 }
 
-resource azureOpenAIProduct 'Microsoft.ApiManagement/service/products@2023-05-01-preview' = {
+resource azureOpenAIProduct 'Microsoft.ApiManagement/service/products@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-product'
   properties: {
@@ -234,13 +267,13 @@ var azureOpenAIAPINames = [
   helperAPI.name
 ]
 
-resource azureOpenAIProductAPIAssociation 'Microsoft.ApiManagement/service/products/apis@2023-05-01-preview' = [
+resource azureOpenAIProductAPIAssociation 'Microsoft.ApiManagement/service/products/apis@2024-05-01' = [
   for apiName in azureOpenAIAPINames: {
     name: '${apiManagementServiceName}/${azureOpenAIProduct.name}/${apiName}'
   }
 ]
 
-resource ptuBackendOne 'Microsoft.ApiManagement/service/backends@2023-05-01-preview' = {
+resource ptuBackendOne 'Microsoft.ApiManagement/service/backends@2024-05-01' = {
   parent: apiManagementService
   name: 'ptu-backend-1'
   properties: {
@@ -254,7 +287,7 @@ resource ptuBackendOne 'Microsoft.ApiManagement/service/backends@2023-05-01-prev
   }
 }
 
-resource ptuBackendOneWithCircuitBreaker 'Microsoft.ApiManagement/service/backends@2023-05-01-preview' = {
+resource ptuBackendOneWithCircuitBreaker 'Microsoft.ApiManagement/service/backends@2024-05-01' = {
   parent: apiManagementService
   name: 'ptu-backend-1-with-circuit-breaker'
   properties: {
@@ -290,7 +323,7 @@ resource ptuBackendOneWithCircuitBreaker 'Microsoft.ApiManagement/service/backen
   }
 }
 
-resource payAsYouGoBackendOne 'Microsoft.ApiManagement/service/backends@2023-05-01-preview' = {
+resource payAsYouGoBackendOne 'Microsoft.ApiManagement/service/backends@2024-05-01' = {
   parent: apiManagementService
   name: 'payg-backend-1'
   properties: {
@@ -304,7 +337,7 @@ resource payAsYouGoBackendOne 'Microsoft.ApiManagement/service/backends@2023-05-
   }
 }
 
-resource payAsYouGoBackendTwo 'Microsoft.ApiManagement/service/backends@2023-05-01-preview' = {
+resource payAsYouGoBackendTwo 'Microsoft.ApiManagement/service/backends@2024-05-01' = {
   parent: apiManagementService
   name: 'payg-backend-2'
   properties: {
@@ -384,7 +417,7 @@ resource retryWithPayAsYouGoBackendPool 'Microsoft.ApiManagement/service/backend
   }
 }
 
-resource azureOpenAIProductSubscriptionOne 'Microsoft.ApiManagement/service/subscriptions@2023-05-01-preview' = {
+resource azureOpenAIProductSubscriptionOne 'Microsoft.ApiManagement/service/subscriptions@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-product-subscription-one'
   properties: {
@@ -394,7 +427,7 @@ resource azureOpenAIProductSubscriptionOne 'Microsoft.ApiManagement/service/subs
   }
 }
 
-resource azureOpenAIProductSubscriptionTwo 'Microsoft.ApiManagement/service/subscriptions@2023-05-01-preview' = {
+resource azureOpenAIProductSubscriptionTwo 'Microsoft.ApiManagement/service/subscriptions@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-product-subscription-two'
   properties: {
@@ -404,7 +437,7 @@ resource azureOpenAIProductSubscriptionTwo 'Microsoft.ApiManagement/service/subs
   }
 }
 
-resource azureOpenAIProductSubscriptionThree 'Microsoft.ApiManagement/service/subscriptions@2023-05-01-preview' = {
+resource azureOpenAIProductSubscriptionThree 'Microsoft.ApiManagement/service/subscriptions@2024-05-01' = {
   parent: apiManagementService
   name: 'aoai-product-subscription-three'
   properties: {
@@ -414,7 +447,7 @@ resource azureOpenAIProductSubscriptionThree 'Microsoft.ApiManagement/service/su
   }
 }
 
-resource simpleRoundRobinPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource simpleRoundRobinPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'simple-round-robin'
   properties: {
@@ -424,7 +457,7 @@ resource simpleRoundRobinPolicyFragment 'Microsoft.ApiManagement/service/policyF
   dependsOn: [payAsYouGoBackendOne, payAsYouGoBackendTwo]
 }
 
-resource azureOpenAISimpleRoundRobinAPIPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAISimpleRoundRobinAPIPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAISimpleRoundRobinAPI
   name: 'policy'
   properties: {
@@ -434,7 +467,7 @@ resource azureOpenAISimpleRoundRobinAPIPolicy 'Microsoft.ApiManagement/service/a
   dependsOn: [simpleRoundRobinPolicyFragment]
 }
 
-resource simpleRoundRobinPolicyFragmentv2 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource simpleRoundRobinPolicyFragmentv2 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'simple-round-robin-v2'
   properties: {
@@ -444,7 +477,7 @@ resource simpleRoundRobinPolicyFragmentv2 'Microsoft.ApiManagement/service/polic
   dependsOn: [simpleRoundRobinBackendPool]
 }
 
-resource azureOpenAISimpleRoundRobinAPIPolicyv2 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAISimpleRoundRobinAPIPolicyv2 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAISimpleRoundRobinAPIv2
   name: 'policy'
   properties: {
@@ -454,7 +487,7 @@ resource azureOpenAISimpleRoundRobinAPIPolicyv2 'Microsoft.ApiManagement/service
   dependsOn: [simpleRoundRobinPolicyFragmentv2]
 }
 
-resource weightedRoundRobinPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource weightedRoundRobinPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'weighted-round-robin'
   properties: {
@@ -464,7 +497,7 @@ resource weightedRoundRobinPolicyFragment 'Microsoft.ApiManagement/service/polic
   dependsOn: [payAsYouGoBackendOne, payAsYouGoBackendTwo]
 }
 
-resource azureOpenAIWeightedRoundRobinAPIPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIWeightedRoundRobinAPIPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIWeightedRoundRobinAPI
   name: 'policy'
   properties: {
@@ -474,7 +507,7 @@ resource azureOpenAIWeightedRoundRobinAPIPolicy 'Microsoft.ApiManagement/service
   dependsOn: [weightedRoundRobinPolicyFragment]
 }
 
-resource weightedRoundRobinPolicyFragmentv2 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource weightedRoundRobinPolicyFragmentv2 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'weighted-round-robin-v2'
   properties: {
@@ -484,7 +517,7 @@ resource weightedRoundRobinPolicyFragmentv2 'Microsoft.ApiManagement/service/pol
   dependsOn: [weightedRoundRobinBackendPool]
 }
 
-resource azureOpenAIWeightedRoundRobinAPIPolicyv2 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIWeightedRoundRobinAPIPolicyv2 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIWeightedRoundRobinAPIv2
   name: 'policy'
   properties: {
@@ -494,7 +527,7 @@ resource azureOpenAIWeightedRoundRobinAPIPolicyv2 'Microsoft.ApiManagement/servi
   dependsOn: [weightedRoundRobinPolicyFragmentv2]
 }
 
-resource retryWithPayAsYouGoPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource retryWithPayAsYouGoPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'retry-with-payg'
   properties: {
@@ -504,7 +537,7 @@ resource retryWithPayAsYouGoPolicyFragment 'Microsoft.ApiManagement/service/poli
   dependsOn: [ptuBackendOne, payAsYouGoBackendOne]
 }
 
-resource azureOpenAIRetryWithPayAsYouGoAPIPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIRetryWithPayAsYouGoAPIPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIRetryWithPayAsYouGoAPI
   name: 'policy'
   properties: {
@@ -514,7 +547,7 @@ resource azureOpenAIRetryWithPayAsYouGoAPIPolicy 'Microsoft.ApiManagement/servic
   dependsOn: [retryWithPayAsYouGoPolicyFragment]
 }
 
-resource retryWithPayAsYouGoPolicyFragmentv2 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource retryWithPayAsYouGoPolicyFragmentv2 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'retry-with-payg-v2'
   properties: {
@@ -524,7 +557,7 @@ resource retryWithPayAsYouGoPolicyFragmentv2 'Microsoft.ApiManagement/service/po
   dependsOn: [retryWithPayAsYouGoBackendPool]
 }
 
-resource azureOpenAIRetryWithPayAsYouGoAPIPolicyv2 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIRetryWithPayAsYouGoAPIPolicyv2 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIRetryWithPayAsYouGoAPIv2
   name: 'policy'
   properties: {
@@ -534,7 +567,7 @@ resource azureOpenAIRetryWithPayAsYouGoAPIPolicyv2 'Microsoft.ApiManagement/serv
   dependsOn: [retryWithPayAsYouGoPolicyFragmentv2]
 }
 
-resource latencyRoutingInboundPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource latencyRoutingInboundPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'latency-routing-inbound'
   properties: {
@@ -544,7 +577,7 @@ resource latencyRoutingInboundPolicyFragment 'Microsoft.ApiManagement/service/po
   dependsOn: [payAsYouGoBackendOne]
 }
 
-resource latencyRoutingBackendPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource latencyRoutingBackendPolicyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'latency-routing-backend'
   properties: {
@@ -553,7 +586,7 @@ resource latencyRoutingBackendPolicyFragment 'Microsoft.ApiManagement/service/po
   }
 }
 
-resource azureOpenAILatencyRoutingPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAILatencyRoutingPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAILatencyRoutingAPI
   name: 'policy'
   properties: {
@@ -563,7 +596,7 @@ resource azureOpenAILatencyRoutingPolicy 'Microsoft.ApiManagement/service/apis/p
   dependsOn: [latencyRoutingInboundPolicyFragment, latencyRoutingBackendPolicyFragment]
 }
 
-resource usageTrackingPolicyFragmentInbound 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource usageTrackingPolicyFragmentInbound 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'usage-tracking-inbound'
   properties: {
@@ -573,7 +606,7 @@ resource usageTrackingPolicyFragmentInbound 'Microsoft.ApiManagement/service/pol
   dependsOn: [payAsYouGoBackendOne]
 }
 
-resource usageTrackingPolicyFragmentOutbound 'Microsoft.ApiManagement/service/policyFragments@2023-05-01-preview' = {
+resource usageTrackingPolicyFragmentOutbound 'Microsoft.ApiManagement/service/policyFragments@2024-05-01' = {
   parent: apiManagementService
   name: 'usage-tracking-outbound'
   properties: {
@@ -583,7 +616,7 @@ resource usageTrackingPolicyFragmentOutbound 'Microsoft.ApiManagement/service/po
   dependsOn: [eventHubLogger]
 }
 
-resource azureOpenAIUsageTrackingPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIUsageTrackingPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIUsageTrackingAPI
   name: 'policy'
   properties: {
@@ -593,7 +626,7 @@ resource azureOpenAIUsageTrackingPolicy 'Microsoft.ApiManagement/service/apis/po
   dependsOn: [usageTrackingPolicyFragmentInbound, usageTrackingPolicyFragmentOutbound]
 }
 
-resource azureOpenAIPrioritizationTokenCalculatingPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIPrioritizationTokenCalculatingPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIPrioritizationTokenCalculatingAPI
   name: 'policy'
   properties: {
@@ -602,7 +635,7 @@ resource azureOpenAIPrioritizationTokenCalculatingPolicy 'Microsoft.ApiManagemen
   }
 }
 
-resource azureOpenAIPrioritizationTokenTrackingPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource azureOpenAIPrioritizationTokenTrackingPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: azureOpenAIPrioritizationTokenTrackingAPI
   name: 'policy'
   properties: {
@@ -611,7 +644,7 @@ resource azureOpenAIPrioritizationTokenTrackingPolicy 'Microsoft.ApiManagement/s
   }
 }
 
-resource helperAPISetPreferredBackends 'Microsoft.ApiManagement/service/apis/policies@2023-05-01-preview' = {
+resource helperAPISetPreferredBackends 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   parent: helperAPI
   name: 'policy'
   properties: {
@@ -685,7 +718,7 @@ resource azureMonitorLogger 'Microsoft.ApiManagement/service/loggers@2022-04-01-
   }
 }
 
-resource allApisAzureMonitorDiagnostics 'Microsoft.ApiManagement/service/diagnostics@2023-05-01-preview' = {
+resource allApisAzureMonitorDiagnostics 'Microsoft.ApiManagement/service/diagnostics@2024-05-01' = {
   parent: apiManagementService
   name: 'azuremonitor'
   properties: {
@@ -727,7 +760,7 @@ resource allApisAzureMonitorDiagnostics 'Microsoft.ApiManagement/service/diagnos
   }
 }
 
-resource azureOpenAIUsageTrackingAPIDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2023-05-01-preview' = {
+resource azureOpenAIUsageTrackingAPIDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2024-05-01' = {
   parent: azureOpenAIUsageTrackingAPI
   name: 'applicationinsights'
   properties: {
@@ -736,7 +769,7 @@ resource azureOpenAIUsageTrackingAPIDiagnostics 'Microsoft.ApiManagement/service
   }
 }
 
-resource azureOpenAIPrioritizationTokenCalculatingAPIDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2023-05-01-preview' = {
+resource azureOpenAIPrioritizationTokenCalculatingAPIDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2024-05-01' = {
   parent: azureOpenAIPrioritizationTokenCalculatingAPI
   name: 'applicationinsights'
   properties: {
@@ -745,7 +778,7 @@ resource azureOpenAIPrioritizationTokenCalculatingAPIDiagnostics 'Microsoft.ApiM
   }
 }
 
-resource azureOpenAIPrioritizationTokenTrackingAPIDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2023-05-01-preview' = {
+resource azureOpenAIPrioritizationTokenTrackingAPIDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2024-05-01' = {
   parent: azureOpenAIPrioritizationTokenTrackingAPI
   name: 'applicationinsights'
   properties: {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- set min api version in both Bicep and Terraform deployments to 2019-12-01 as per portal advisary
![image](https://github.com/user-attachments/assets/018cd85d-ea43-4f8a-908e-3db88cf0300b)
- Update ARM api versions for APIM resources to non-preview version


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: maintenance/security fix
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->