### PR TITLE
feat(e2e): Honor gateway hostname in scenario runner

### DIFF
--- a/scripts/utils/run-end-to-end-test.sh
+++ b/scripts/utils/run-end-to-end-test.sh
@@ -112,13 +112,11 @@ if [[ -z "${apim_subscription_three_key}" ]]; then
 	exit 1
 fi
 
-apim_name=$(jq -r '.apiManagementName // ""' < "$output_main")
-if [[ -z "${apim_name}" ]]; then
-	echo "APIM Name not found in output.json"
+apim_base_url=$(jq -r '.apiManagementGatewayHostname // ""' < "$output_main")
+if [[ -z "${apim_base_url}" ]]; then
+    echo "APIM Hostname not found in output.json"
 	exit 1
 fi
-apim_base_url="https://${apim_name}.azure-api.net"
-
 
 subscription_id=$(az account show --output tsv --query id)
 tenant_id=$(az account show --output tsv --query tenantId)


### PR DESCRIPTION
## Summary

This PR updates the end-to-end test runner to read the actual gateway hostname from deployment outputs instead of constructing it from the APIM name.

## Motivation

Our APIM deployment uses a different hostname (including custom domains), so the current behavior of constructing `https://${apim_name}.azure-api.net` doesn't work for our environment. We still want to leverage these tests against our gateway infrastructure.

## Changes

- **Read `apiManagementGatewayHostname`** from `output.json` so we target the actual APM gateway host (including custom domains)
- **Fail early** when the hostname is missing instead of silently constructing an invalid default URL
- **Keep the end-to-end harness aligned** with deployment outputs rather than hard-coded assumptions

## Files Changed

- `scripts/utils/run-end-to-end-test.sh`

## Testing

- Verified the script correctly reads the hostname from deployment outputs
- Tested with custom domain configurations

## Checklist

- [x] Changes follow the existing code style
- [x] Commit message follows the project conventions
- [x] No duplicate effort (searched existing PRs)